### PR TITLE
Improved URL Parsing

### DIFF
--- a/command/cmd_run.go
+++ b/command/cmd_run.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/urfave/cli/v2"
+    "github.com/kballard/go-shellquote"
 
 	"github.com/peak/s5cmd/parallel"
 )
@@ -68,7 +69,11 @@ var RunCommand = &cli.Command{
 				continue
 			}
 
-			fields := strings.Fields(line)
+			fields, err := shellquote.Split(line)
+			if err != nil {
+				return err
+			}
+
 			if len(fields) == 0 {
 				continue
 			}

--- a/command/cmd_run.go
+++ b/command/cmd_run.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 
 	"github.com/urfave/cli/v2"
-    "github.com/kballard/go-shellquote"
+	"github.com/kballard/go-shellquote"
 
 	"github.com/peak/s5cmd/parallel"
 )

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/iancoleman/strcase v0.0.0-20191112232945-16388991a334
 	github.com/johannesboyne/gofakes3 v0.0.0-20191228161223-9aee1c78a252
 	github.com/karrick/godirwalk v1.15.3
+	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51
 	github.com/kr/pretty v0.2.0 // indirect
 	github.com/posener/complete v1.2.3
 	github.com/termie/go-shutil v0.0.0-20140729215957-bcacb06fecae

--- a/go.sum
+++ b/go.sum
@@ -26,6 +26,8 @@ github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af h1:pmfjZENx5i
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/karrick/godirwalk v1.15.3 h1:0a2pXOgtB16CqIqXTiT7+K9L73f74n/aNQUnH6Ortew=
 github.com/karrick/godirwalk v1.15.3/go.mod h1:j4mkqPuvaLI8mp1DroR3P6ad7cyYd4c1qeJ3RV7ULlk=
+github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 h1:Z9n2FFNUXsshfwJMBgNA0RU6/i7WVaAegv3PtuIHPMs=
+github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51/go.mod h1:CzGEWj7cYgsdH8dAjBGEr58BoE7ScuLd+fwFZ44+/x8=
 github.com/kr/pretty v0.2.0 h1:s5hAObm+yFO5uHYt5dYjxi2rXrsnmRpJx4OYvIWUaQs=
 github.com/kr/pretty v0.2.0/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=

--- a/objurl/objurl.go
+++ b/objurl/objurl.go
@@ -23,7 +23,7 @@ const (
 	matchAllRe string = ".*"
 
 	// regexCharacters need to be escaped to be interpreted literally
-    regexCharacters string = "\\^$.|?*+()[{"
+	regexCharacters string = "\\^$.|?*+()[{"
 )
 
 type objurlType int
@@ -212,9 +212,9 @@ func (o *ObjectURL) setPrefixAndFilter() error {
 		o.Prefix = o.Path[:loc]
 		o.filter = o.Path[loc:]
 	}
-	for _, char := range regexCharacters {
-        o.Prefix = strings.Replace(o.Prefix, string(char), "\\" + string(char), -1)
-    }
+	for _, char := range regexCharacters
+		o.Prefix = strings.Replace(o.Prefix, string(char), "\\" + string(char), -1)
+	}
 
 	filterRegex := matchAllRe
 	if o.filter != "" {

--- a/objurl/objurl.go
+++ b/objurl/objurl.go
@@ -212,7 +212,7 @@ func (o *ObjectURL) setPrefixAndFilter() error {
 		o.Prefix = o.Path[:loc]
 		o.filter = o.Path[loc:]
 	}
-	for _, char := range regexCharacters
+	for _, char := range regexCharacters {
 		o.Prefix = strings.Replace(o.Prefix, string(char), "\\" + string(char), -1)
 	}
 

--- a/objurl/objurl.go
+++ b/objurl/objurl.go
@@ -21,6 +21,9 @@ const (
 
 	// matchAllRe is the regex to match everything
 	matchAllRe string = ".*"
+
+	// regexCharacters need to be escaped to be interpreted literally
+    regexCharacters string = "\\^$.|?*+()[{"
 )
 
 type objurlType int
@@ -209,6 +212,9 @@ func (o *ObjectURL) setPrefixAndFilter() error {
 		o.Prefix = o.Path[:loc]
 		o.filter = o.Path[loc:]
 	}
+	for _, char := range regexCharacters {
+        o.Prefix = strings.Replace(o.Prefix, string(char), "\\" + string(char), -1)
+    }
 
 	filterRegex := matchAllRe
 	if o.filter != "" {


### PR DESCRIPTION
- Use `shellquote` to split lines in `commands.txt` files so filenames with spaces can be used
- Escape regex characters when initializing `ObjectURL`s. These are valid S3 paths.