### PR TITLE
Fix tests

### DIFF
--- a/e2e/run_test.go
+++ b/e2e/run_test.go
@@ -234,7 +234,7 @@ func TestRunSpecialCharactersInPrefix(t *testing.T) {
 	putFile(t, s3client, bucket, "file.txt", "content")
 
 	content := []string{
-		"cp \"s3://" + bucket + "special-chars_!@#$%^&_()_+{[_%5Cäè| __;'_,_._-中文 =/_!@#$%^&_()_+{[_%5Cäè| __;'_,_._-中文 =image.jpg\" ./image.jpg",
+		`cp "s3://` + bucket + `/special-chars_!@#$%^&_()_+{[_%5Cäè| __;'_,_._-中文 =/_!@#$%^&_()_+{[_%5Cäè| __;'_,_._-中文 =image.jpg" ./image.jpg`,
 	}
 	file := fs.NewFile(t, "prefix", fs.WithContent(strings.Join(content, "\n")))
 	defer file.Remove()
@@ -245,7 +245,8 @@ func TestRunSpecialCharactersInPrefix(t *testing.T) {
 	result.Assert(t, icmd.Success)
 
 	assertLines(t, result.Stdout(), map[int]compareFunc{
-		0: equals("cp s3://" + bucket + "/special-chars_!@#$%^&_()_+{[_%5Cäè| __;'_,_._-中文 =/_!@#$%^&_()_+{[_%5Cäè| __;'_,_._-中文 =image.jpg"),
+		0: equals(""),
+		1: equals(`cp s3://` + bucket + `/special-chars_!@#$%^&_()_+{[_%5Cäè| __;'_,_._-中文 =/_!@#$%^&_()_+{[_%5Cäè| __;'_,_._-中文 =image.jpg`),
 	}, sortInput(true))
 
 	assertLines(t, result.Stderr(), map[int]compareFunc{

--- a/e2e/util_test.go
+++ b/e2e/util_test.go
@@ -414,7 +414,12 @@ func isJSON(str string) bool {
 }
 
 func equals(format string, args ...interface{}) compareFunc {
-	expected := fmt.Sprintf(format, args...)
+	expected := ""
+	if len(args) > 0 {
+		expected = fmt.Sprintf(format, args...)
+	} else {
+		expected = format
+	}
 	return func(actual string) error {
 		if expected == actual {
 			return nil

--- a/objurl/objurl.go
+++ b/objurl/objurl.go
@@ -209,7 +209,6 @@ func (o *ObjectURL) setPrefixAndFilter() error {
 		o.Prefix = o.Path[:loc]
 		o.filter = o.Path[loc:]
 	}
-	o.Prefix = regexp.QuoteMeta(o.Prefix)
 
 	filterRegex := matchAllRe
 	if o.filter != "" {
@@ -217,7 +216,7 @@ func (o *ObjectURL) setPrefixAndFilter() error {
 		filterRegex = strings.Replace(filterRegex, "\\?", ".", -1)
 		filterRegex = strings.Replace(filterRegex, "\\*", ".*?", -1)
 	}
-	filterRegex = o.Prefix + filterRegex
+	filterRegex = regexp.QuoteMeta(o.Prefix) + filterRegex
 	r, err := regexp.Compile("^" + filterRegex + "$")
 	if err != nil {
 		return err


### PR DESCRIPTION
- Don't overwrite o.Prefix
- Add empty line 0, use backticks
- Don't `Sprintf` string if it has no arguments to allow for strings containing literal %